### PR TITLE
Fix MSVC build

### DIFF
--- a/lev/src/config.h
+++ b/lev/src/config.h
@@ -2,6 +2,11 @@
 
 #define EV_MULTIPLICITY 1
 
+#ifdef _MSC_VER
+#define HAVE_SYS_SELECT_H 1
+#define HAVE_SELECT 1
+#else /* _MSC_VER */
+
 #if __has_include(<sys/inotify.h>)
 #define HAVE_SYS_INOTIFY_H 1
 #endif
@@ -64,5 +69,7 @@
 #if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
 #define HAVE_NANOSLEEP 1
 #endif
+
+#endif /* _MSC_VER */
 
 #define HAVE_FLOOR 1

--- a/lev/src/dune
+++ b/lev/src/dune
@@ -10,7 +10,6 @@
   (backend bisect_ppx))
  (foreign_stubs
   (language c)
-  (flags :standard -libm)
   (extra_deps
    ev_kqueue.c
    ev_epoll.c


### PR DESCRIPTION
See ocaml/ocaml-lsp#677

- Remove `-libm` from the C stubs compilation flags; it is a linking flag so as far as I can see it would be ignored when compiling the C stubs anyway.
- Tweak the preprocessor directives in `config.h`: under MSVC  hard-code only "select" support.