### PR TITLE
Fix Lev_fiber.waitpid on Windows

### DIFF
--- a/lev-fiber/src/lev_fiber.ml
+++ b/lev-fiber/src/lev_fiber.ml
@@ -1034,7 +1034,8 @@ let run lev_loop ~f =
               None
             with Finished (job, status) -> Some (job, status)
           in
-          watcher.process_thread <- lazy (run_thread watcher);
+          watcher.process_thread <-
+            lazy (Thread.spawn_thread @@ fun () -> run_thread watcher);
           Some watcher
     in
     let tval =

--- a/lev-fiber/src/lev_fiber.ml
+++ b/lev-fiber/src/lev_fiber.ml
@@ -1037,7 +1037,7 @@ let run lev_loop ~f =
           watcher.process_thread <- lazy (run_thread watcher);
           Some watcher
     in
-    Fiber.Var.set t
+    let tval =
       {
         loop = lev_loop;
         queue;
@@ -1046,7 +1046,9 @@ let run lev_loop ~f =
         thread_jobs;
         process_watcher;
       }
-      f
+    in
+    Fdecl.set tref tval;
+    Fiber.Var.set t tval f
   in
   let rec events q acc =
     match Queue.pop q with None -> acc | Some e -> events q (e :: acc)

--- a/lev-fiber/src/lev_fiber.ml
+++ b/lev-fiber/src/lev_fiber.ml
@@ -1019,10 +1019,11 @@ let run lev_loop ~f =
             Option.iter result ~f:(fun (job, _) ->
                 Table.remove watcher.active job.pid);
             Mutex.unlock watcher.mutex;
-            Option.iter result ~f:(fun (job, status) ->
-                finish_job (Fdecl.get tref) (Fiber.Fill (job.ivar, status));
-                run_thread watcher);
-            Unix.sleepf 0.05
+            (match result with
+            | None -> Unix.sleepf 0.05
+            | Some (job, status) ->
+                finish_job (Fdecl.get tref) (Fiber.Fill (job.ivar, status)));
+            run_thread watcher
           and check_running watcher =
             try
               Table.iter watcher.active ~f:(fun (job : process) ->


### PR DESCRIPTION
Modifications so far:
- Forcing `process_thread` after adding a process to the `active` table
- Always recursively call `run_thread`
- Using `Fdecl.set` to set `tref` (it wasn't being set at all before, causing an exception)

Now it seems that the `ivar` does get filled, but then it runs in an infinite loop.

I think I might be misunderstanding how this function is supposed to work. Is it supposed to be running in a separate thread or something? It doesn't look like it's doing that now.