### PR TITLE
Include necessary header on FreeBSD and OpenBSD

### DIFF
--- a/lev/src/lev_stubs.c
+++ b/lev/src/lev_stubs.c
@@ -3,7 +3,9 @@
 #include <stdbool.h>
 
 #include <math.h>
-
+#if (defined(__FreeBSD__) || defined(__OpenBSD__))
+#include <sys/wait.h>
+#endif
 #define TAG_WEXITED 0
 #define TAG_WSIGNALED 1
 #define TAG_WSTOPPED 2


### PR DESCRIPTION
On FreeBSD and OpenBSD, when we use  WIFEXITED,WEXITSTATUS,WIFSTOPPED,WSTOPSIG and WTERMSIG, we need to include `sys/wait.h` . 
 