### PR TITLE
test(lev): signal feeding

### DIFF
--- a/lev/test/dune
+++ b/lev/test/dune
@@ -39,6 +39,7 @@
   (<> %{system} win))
  (libraries
   lev
+  threads.posix
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/lev/test/lev_tests_signals.ml
+++ b/lev/test/lev_tests_signals.ml
@@ -1,13 +1,14 @@
 open Lev
 
+let flags = Loop.Flag.(Set.singleton Nosigmask)
+
 let%expect_test "signal handling" =
   let signal = Sys.sigusr1 in
-  let flags = Loop.Flag.(Set.singleton Nosigmask) in
   let loop = Loop.create ~flags () in
   let signal_watcher =
     Signal.create ~signal (fun t ->
         print_endline "received signal";
-        ignore (Unix.sigprocmask Unix.SIG_BLOCK [ signal ]);
+        ignore (Unix.sigprocmask SIG_BLOCK [ signal ]);
         Signal.stop t loop)
   in
   let idle =
@@ -22,3 +23,31 @@ let%expect_test "signal handling" =
   [%expect {|
     sending signal
     received signal |}]
+
+let%expect_test "manual signal feeding" =
+  let signal = Sys.sigusr2 in
+  ignore (Unix.sigprocmask SIG_BLOCK [ signal ]);
+  let thread =
+    Thread.create
+      (fun () ->
+        print_endline "thread: awaiting signal";
+        ignore (Thread.wait_signal [ signal ]);
+        Loop.feed_signal ~signal;
+        print_endline "thread: awaited signal")
+      ()
+  in
+  let loop = Loop.create () in
+  let signal_watcher =
+    Signal.create ~signal (fun w ->
+        print_endline "lev: received signal";
+        Signal.stop w loop)
+  in
+  Signal.start signal_watcher loop;
+  Unix.kill (Unix.getpid ()) signal;
+  Loop.run_until_done loop;
+  Thread.join thread;
+  [%expect
+    {|
+    thread: awaiting signal
+    thread: awaited signal
+    lev: received signal |}]


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 24dcfb5f-cdd8-456f-b6f0-d9a17e10f11b