### PR TITLE
fix(lev): build ev standalone

### DIFF
--- a/lev/src/dune
+++ b/lev/src/dune
@@ -2,20 +2,26 @@
 
 (copy_files# ../vendor/{ev,ev_vars,ev_wrap}.h)
 
+(foreign_library
+ (archive_name ev)
+ (extra_deps
+  ev_kqueue.c
+  ev_epoll.c
+  ev_iouring.c
+  ev_poll.c
+  ev_port.c
+  ev_select.c
+  ev_win32.c)
+ (language c)
+ (names ev))
+
 (library
  (public_name lev)
  (synopsis "libev bindings")
  (libraries unix)
+ (foreign_archives ev)
  (instrumentation
   (backend bisect_ppx))
  (foreign_stubs
   (language c)
-  (extra_deps
-   ev_kqueue.c
-   ev_epoll.c
-   ev_iouring.c
-   ev_poll.c
-   ev_port.c
-   ev_select.c
-   ev_win32.c)
-  (names lev_stubs ev)))
+  (names lev_stubs)))


### PR DESCRIPTION
without including unnecessary headers from ocaml itself

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 54e73b82-8805-4265-b953-9863b403cb85