### PR TITLE
fix(lev-fiber): cleanup threads

### DIFF
--- a/lev-fiber/src/util/worker.ml
+++ b/lev-fiber/src/util/worker.ml
@@ -1,17 +1,22 @@
-type 'a t = { work_chan : 'a Channel.t } [@@unboxed]
+module Id = Int
+
+type 'a t = { work_chan : 'a Channel.t; thread : Thread.t }
 type task = Channel.elt_in_channel
 
-let rec run t f =
-  match Channel.get t.work_chan with
+let id t = Thread.id t.thread
+let join t = Thread.join t.thread
+
+let rec run work_chan f =
+  match Channel.get work_chan with
+  | Error `Closed -> ()
   | Ok v ->
       f v;
-      run t f
-  | Error `Closed -> ()
+      run work_chan f
 
 let create ~spawn_thread ~do_no_raise =
-  let t = { work_chan = Channel.create () } in
-  spawn_thread (fun () -> run t do_no_raise);
-  t
+  let work_chan = Channel.create () in
+  let thread = spawn_thread (fun () -> run work_chan do_no_raise) in
+  { work_chan; thread }
 
 let add_work t v =
   match Channel.send_removable t.work_chan v with

--- a/lev-fiber/src/util/worker.mli
+++ b/lev-fiber/src/util/worker.mli
@@ -2,7 +2,7 @@ type 'work t
 (** Simple queue that is consumed by its own thread *)
 
 val create :
-  spawn_thread:((unit -> unit) -> unit) -> do_no_raise:('a -> unit) -> 'a t
+  spawn_thread:((unit -> unit) -> Thread.t) -> do_no_raise:('a -> unit) -> 'a t
 (** [create ~spawn_thread ~do_no_raise] creates a worker with a task handler
     [do_no_raise]. The worker will not handle an exception raised by the task
     handler, so [do_no_raise] is expected to not raise. [spawn_thread] is used
@@ -15,6 +15,15 @@ val cancel_if_not_consumed : task -> unit
     thread. Does nothing if the task has been consumed already. *)
 
 val add_work : 'a t -> 'a -> (task, [ `Stopped ]) result
+
+module Id : sig
+  type t
+
+  val equal : t -> t -> bool
+end
+
+val id : _ t -> Id.t
+val join : _ t -> unit
 
 val complete_tasks_and_stop : _ t -> unit
 (** Signals the worker to complete tasks currently available in the queue and


### PR DESCRIPTION
When Lev_fiber.run finishes, clean up all running threads

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: bec4347d-e81e-4e6d-8f08-89566f7e1ed4