### PR TITLE
fix(lev-fiber): signal handling and epipe handling

### DIFF
--- a/lev-fiber/src/lev_fiber.mli
+++ b/lev-fiber/src/lev_fiber.mli
@@ -161,5 +161,9 @@ end
 val yield : unit -> unit Fiber.t
 (** [yield ()] wait for one iteration of the event loop *)
 
-val run : ?flags:Lev.Loop.Flag.Set.t -> (unit -> 'a Fiber.t) -> 'a
+val run :
+  ?sigpipe:[ `Inherit | `Ignore ] ->
+  ?flags:Lev.Loop.Flag.Set.t ->
+  (unit -> 'a Fiber.t) ->
+  'a
 (** If you set [flags] manually, you must include the [Nosigprocmask] flag *)


### PR DESCRIPTION
* Stop touching the signal mask with [Lev].
* Give user option to ignore [SIGPIPE].
* Carefully restore all signal behavior after Lev_fiber.run terminates

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 652b880c-8617-406d-bf7a-e5ccc62af5f1