### PR TITLE
fix building on FreeBSD 15.0+

### DIFF
--- a/lev/vendor/ev.c
+++ b/lev/vendor/ev.c
@@ -510,13 +510,13 @@
 # endif
 #endif
 
-#if __FreeBSD__
-#define EV_USE_INOTIFY 0
-#define EV_USE_KQUEUE 1
-#endif
-
 #if EV_USE_INOTIFY
-# include <sys/statfs.h>
+/* FreeBSD defines statfs(2) in <sys/mount.h> */
+# ifdef __FreeBSD__
+#  include <sys/mount.h>
+# else
+#  include <sys/statfs.h>
+# endif
 # include <sys/inotify.h>
 /* some very old inotify.h headers don't have IN_DONT_FOLLOW */
 # ifndef IN_DONT_FOLLOW


### PR DESCRIPTION
This is a more proper way to get this to build on FreeBSD 15.0+ than 5ca101c.

The actual issue is that libev assumes that an inotify API being present implies a Linux system. This is no longer the case as of FreeBSD 15.0+ which introduced a Linux-compatible inotify API.

I have also mailed this patch to the libev mailing list; however, I am unsure when or if we can expect them to respond, so I have duplicated this here to allow code depending on lev to build on FreeBSD in the meantime. This commit may be reverted if or when upstream accepts the patch.

This reverts commit 5ca101cde0c69af8d4c5cd7e5ec3f74b9a5c514b.